### PR TITLE
Fix commands, Fix allocation, Add more commands

### DIFF
--- a/Items/Respec.cs
+++ b/Items/Respec.cs
@@ -2,67 +2,61 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
-namespace levelplus.Items
-{
-	public class Respec : ModItem
-	{
-		public override void SetStaticDefaults()
-		{
-			DisplayName.SetDefault("Insignia of Reform");
-			Tooltip.SetDefault("This token enables the reallocation of Level+ skill points.\nHoist this token to return all Level+ invested skill points to the skill point pool.\nUnallocated points can be reinvested into skills again.");
-		}
+namespace levelplus.Items {
+    public class Respec : ModItem {
+        public override void SetStaticDefaults() {
+            DisplayName.SetDefault("Insignia of Reform");
+            Tooltip.SetDefault("This token enables the reallocation of Level+ skill points.\nHoist this token to return all Level+ invested skill points to the skill point pool.\nUnallocated points can be reinvested into skills again.");
+        }
 
-		public override void SetDefaults()
-		{
-			Item.width = 40;
-			Item.height = 40;
-			Item.useTime = 20;
-			Item.useAnimation = 20;
-			Item.useStyle = ItemUseStyleID.HoldUp;
-			Item.maxStack = 1;
-			Item.consumable = true;
-			Item.value = Item.buyPrice(0, 5, 0, 0);
-			Item.rare = ItemRarityID.Lime;
-			Item.UseSound = SoundID.Item4;
-		}
+        public override void SetDefaults() {
+            Item.width = 40;
+            Item.height = 40;
+            Item.useTime = 20;
+            Item.useAnimation = 20;
+            Item.useStyle = ItemUseStyleID.HoldUp;
+            Item.maxStack = 1;
+            Item.consumable = true;
+            Item.value = Item.buyPrice(0, 5, 0, 0);
+            Item.rare = ItemRarityID.Lime;
+            Item.UseSound = SoundID.Item4;
+        }
 
-		public override void AddRecipes()
-		{
-			CreateRecipe()
-				.AddIngredient(ItemID.GoldBar, 1)
-				.AddIngredient(ItemID.SoulofFlight, 1)
-				.AddIngredient(ItemID.SoulofNight, 1)
-				.AddTile(TileID.MythrilAnvil)
-				.Register();
+        public override void AddRecipes() {
+            CreateRecipe()
+                .AddIngredient(ItemID.GoldBar, 1)
+                .AddIngredient(ItemID.SoulofFlight, 1)
+                .AddIngredient(ItemID.SoulofNight, 1)
+                .AddTile(TileID.MythrilAnvil)
+                .Register();
 
-			CreateRecipe()
-				.AddIngredient(ItemID.GoldBar, 1)
-				.AddIngredient(ItemID.SoulofFlight, 1)
-				.AddIngredient(ItemID.SoulofLight, 1)
-				.AddTile(TileID.MythrilAnvil)
-				.Register();
+            CreateRecipe()
+                .AddIngredient(ItemID.GoldBar, 1)
+                .AddIngredient(ItemID.SoulofFlight, 1)
+                .AddIngredient(ItemID.SoulofLight, 1)
+                .AddTile(TileID.MythrilAnvil)
+                .Register();
 
-			CreateRecipe()
-				.AddIngredient(ItemID.PlatinumBar, 1)
-				.AddIngredient(ItemID.SoulofFlight, 1)
-				.AddIngredient(ItemID.SoulofNight, 1)
-				.AddTile(TileID.MythrilAnvil)
-				.Register();
+            CreateRecipe()
+                .AddIngredient(ItemID.PlatinumBar, 1)
+                .AddIngredient(ItemID.SoulofFlight, 1)
+                .AddIngredient(ItemID.SoulofNight, 1)
+                .AddTile(TileID.MythrilAnvil)
+                .Register();
 
-			CreateRecipe()
-				.AddIngredient(ItemID.PlatinumBar, 1)
-				.AddIngredient(ItemID.SoulofFlight, 1)
-				.AddIngredient(ItemID.SoulofLight, 1)
-				.AddTile(TileID.MythrilAnvil)
-				.Register();
-		}
+            CreateRecipe()
+                .AddIngredient(ItemID.PlatinumBar, 1)
+                .AddIngredient(ItemID.SoulofFlight, 1)
+                .AddIngredient(ItemID.SoulofLight, 1)
+                .AddTile(TileID.MythrilAnvil)
+                .Register();
+        }
 
-		public override bool? UseItem(Player player)
-		{
-			levelplusModPlayer modPlayer = player.GetModPlayer<levelplusModPlayer>();
-			modPlayer.StatReset();
+        public override bool? UseItem(Player player) {
+            levelplusModPlayer modPlayer = player.GetModPlayer<levelplusModPlayer>();
+            modPlayer.StatReset();
 
-			return true;
-		}
-	}
+            return true;
+        }
+    }
 }

--- a/Items/Restart.cs
+++ b/Items/Restart.cs
@@ -2,42 +2,36 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
-namespace levelplus.Items
-{
-	public class Restart : ModItem
-	{
-		public override void SetStaticDefaults()
-		{
-			DisplayName.SetDefault("Insignia of Rebirth");
-			Tooltip.SetDefault("By hoisting this token, you lose the experience you have gained, and return to level 1.\n[c/ff0000:WHEN USED, ALL PROGRESS FOR Level+ WILL BE LOST FOR THIS CHARACTER.]");
-		}
+namespace levelplus.Items {
+    public class Restart : ModItem {
+        public override void SetStaticDefaults() {
+            DisplayName.SetDefault("Insignia of Rebirth");
+            Tooltip.SetDefault("By hoisting this token, you lose the experience you have gained, and return to level 1.\n[c/ff0000:WHEN USED, ALL PROGRESS FOR Level+ WILL BE LOST FOR THIS CHARACTER.]");
+        }
 
-		public override void SetDefaults()
-		{
-			Item.width = 40;
-			Item.height = 40;
-			Item.useTime = 20;
-			Item.useAnimation = 20;
-			Item.useStyle = ItemUseStyleID.HoldUp;
-			Item.maxStack = 1;
-			Item.consumable = true;
-			Item.value = Item.buyPrice(0, 0, 0, 0);
-			Item.rare = ItemRarityID.Lime;
-			Item.UseSound = SoundID.Item4;
-		}
+        public override void SetDefaults() {
+            Item.width = 40;
+            Item.height = 40;
+            Item.useTime = 20;
+            Item.useAnimation = 20;
+            Item.useStyle = ItemUseStyleID.HoldUp;
+            Item.maxStack = 1;
+            Item.consumable = true;
+            Item.value = Item.buyPrice(0, 0, 0, 0);
+            Item.rare = ItemRarityID.Lime;
+            Item.UseSound = SoundID.Item4;
+        }
 
-		public override void AddRecipes()
-		{
-			CreateRecipe()
-				.AddTile(TileID.WorkBenches)
-				.Register();
-		}
+        public override void AddRecipes() {
+            CreateRecipe()
+                .AddTile(TileID.WorkBenches)
+                .Register();
+        }
 
-		public override bool? UseItem(Player player)
-		{
-			player.GetModPlayer<levelplusModPlayer>().initialize();
+        public override bool? UseItem(Player player) {
+            player.GetModPlayer<levelplusModPlayer>().initialize();
 
-			return true;
-		}
-	}
+            return true;
+        }
+    }
 }

--- a/UI/GUI.cs
+++ b/UI/GUI.cs
@@ -1,17 +1,14 @@
 ﻿using Microsoft.Xna.Framework;
 using Terraria.UI;
 
-namespace levelplus.UI
-{
-	internal class GUI : UIState
-	{
-		public static bool visible;
+namespace levelplus.UI {
+    internal class GUI : UIState {
+        public static bool visible;
         private XPBar XPBar;
         private Vector2 placement;
 
-        public override void OnInitialize()
-		{
-			base.OnInitialize();
+        public override void OnInitialize() {
+            base.OnInitialize();
             placement = new Vector2(480, 35);
 
             XPBar = new XPBar(120, 26);
@@ -22,7 +19,7 @@ namespace levelplus.UI
 
             base.Append(XPBar);
             visible = true;
-		}
+        }
 
         public override void OnDeactivate() {
             base.OnDeactivate();

--- a/UI/ResourceBar.cs
+++ b/UI/ResourceBar.cs
@@ -76,7 +76,7 @@ namespace levelplus.UI {
             //calculate quotient
             switch (stat) {
                 case ResourceBarMode.XP:
-                    quotient = modPlayer.currentXP / (float)modPlayer.neededXP;
+                    quotient = modPlayer.currentXP / (float) modPlayer.neededXP;
                     break;
                 default:
                     break;

--- a/UI/SpendUI.cs
+++ b/UI/SpendUI.cs
@@ -16,7 +16,7 @@ namespace levelplus.UI {
             circle = new StatCircle(circleDiameter);
             circle.Left.Set((Main.screenWidth / 2f) - (circleDiameter / 2f), 0f);
             circle.Top.Set((Main.screenHeight / 2f) - (circleDiameter / 2f), 0f);
-            
+
             Append(circle);
         }
 

--- a/UI/StatButton.cs
+++ b/UI/StatButton.cs
@@ -116,60 +116,60 @@ namespace levelplus.UI {
                 case Stat.STRENGTH:
                     points.SetText("" + modPlayer.strength);
                     text = "Strength:\n\n"
-                        + "  +" + ((int)(modPlayer.strength * (levelplusConfig.Instance.MeleeDamagePerPoint * 100))) + "% melee damage\n"
+                        + "  +" + ((int) (modPlayer.strength * (levelplusConfig.Instance.MeleeDamagePerPoint * 100))) + "% melee damage\n"
                         + "  +" + (modPlayer.strength / levelplusConfig.Instance.MeleeCritPerPoint) + "% melee crit chance";
                     rarity = 10; //red
                     break;
                 case Stat.INTELLIGENCE:
                     points.SetText("" + modPlayer.intelligence);
                     text = "Intelligence:\n\n"
-                        + "  +" + ((int)(modPlayer.intelligence * (levelplusConfig.Instance.MagicDamagePerPoint * 100))) + "% magic damage\n"
+                        + "  +" + ((int) (modPlayer.intelligence * (levelplusConfig.Instance.MagicDamagePerPoint * 100))) + "% magic damage\n"
                         + "  +" + (modPlayer.intelligence / levelplusConfig.Instance.MagicCritPerPoint) + "% magic crit chance";
                     rarity = 9; //cyan
                     break;
                 case Stat.CHARISMA:
                     points.SetText("" + modPlayer.charisma);
                     text = "Charisma:\n\n"
-                        + "  +" + ((int)(modPlayer.charisma * (levelplusConfig.Instance.SummonDamagePerPoint * 100))) + "% minion damage\n"
+                        + "  +" + ((int) (modPlayer.charisma * (levelplusConfig.Instance.SummonDamagePerPoint * 100))) + "% minion damage\n"
                         + "  +" + (modPlayer.charisma / levelplusConfig.Instance.SummonCritPerPoint) + "% minion crit chance";
                     rarity = 6; //light purple
                     break;
                 case Stat.DEXTERITY:
                     points.SetText("" + modPlayer.dexterity);
                     text = "Dexterity:\n\n"
-                        + "  +" + ((int)(modPlayer.dexterity * (levelplusConfig.Instance.RangedDamagePerPoint * 100))) + "% ranged damage\n"
+                        + "  +" + ((int) (modPlayer.dexterity * (levelplusConfig.Instance.RangedDamagePerPoint * 100))) + "% ranged damage\n"
                         + "  +" + (modPlayer.dexterity / levelplusConfig.Instance.RangedCritPerPoint) + "% ranged crit chance";
                     rarity = 8; //yellow
                     break;
                 case Stat.MOBILITY:
                     points.SetText("" + modPlayer.mobility);
                     text = "Mobility:\n\n"
-                        + "  +" + ((int)(modPlayer.mobility * (levelplusConfig.Instance.AccelPerPoint * 100))) + "% acceleration\n"
-                        + "  +" + ((int)(modPlayer.mobility * (levelplusConfig.Instance.WingPerPoint * 100))) + "% wing time\n"
-                        + "  +" + ((int)(modPlayer.mobility * (levelplusConfig.Instance.RunSpeedPerPoint * 100))) + "% max run speed";
+                        + "  +" + ((int) (modPlayer.mobility * (levelplusConfig.Instance.AccelPerPoint * 100))) + "% acceleration\n"
+                        + "  +" + ((int) (modPlayer.mobility * (levelplusConfig.Instance.WingPerPoint * 100))) + "% wing time\n"
+                        + "  +" + ((int) (modPlayer.mobility * (levelplusConfig.Instance.RunSpeedPerPoint * 100))) + "% max run speed";
                     rarity = 0; //white
                     break;
                 case Stat.EXCAVATION:
                     points.SetText("" + modPlayer.excavation);
                     text = "Excavation:\n\n"
-                        + "  +" + ((int)(modPlayer.excavation * (levelplusConfig.Instance.PickSpeedPerPoint * 100))) + "% pick speed\n"
-                        + "  +" + ((int)(modPlayer.excavation * (levelplusConfig.Instance.BuildSpeedPerPoint * 100))) + "% place speed\n"
+                        + "  +" + ((int) (modPlayer.excavation * (levelplusConfig.Instance.PickSpeedPerPoint * 100))) + "% pick speed\n"
+                        + "  +" + ((int) (modPlayer.excavation * (levelplusConfig.Instance.BuildSpeedPerPoint * 100))) + "% place speed\n"
                         + "  +" + (modPlayer.excavation / levelplusConfig.Instance.RangePerPoint) + " block range";
                     rarity = 0; //white
                     break;
                 case Stat.ANIMALIA:
                     points.SetText("" + modPlayer.animalia);
                     text = "Animalia:\n\n"
-                        + "  +" + ((int)(modPlayer.animalia * (levelplusConfig.Instance.FishSkillPerPoint * 100))) + "% better fishing\n"
+                        + "  +" + ((int) (modPlayer.animalia * (levelplusConfig.Instance.FishSkillPerPoint * 100))) + "% better fishing\n"
                         + "  +" + (modPlayer.animalia / levelplusConfig.Instance.MinionPerPoint) + " minion slots\n";
-                        //+ "  +" + ((int)(modPlayer.animalia * (levelplusConfig.Instance.MinionKnockBack * 100))) + "% minion knockback";
+                    //+ "  +" + ((int)(modPlayer.animalia * (levelplusConfig.Instance.MinionKnockBack * 100))) + "% minion knockback";
                     rarity = 0; //white
                     break;
                 case Stat.LUCK:
                     points.SetText("" + modPlayer.luck);
                     text = "Luck:\n\n"
-                        + "  +" + ((int)(modPlayer.luck * (levelplusConfig.Instance.XPPerPoint * 100))) + "% xp gain\n"
-                        + "  +" + ((int)((modPlayer.luck * 100) / levelplusConfig.Instance.AmmoPerPoint)) + "% chance not to consume ammo";
+                        + "  +" + ((int) (modPlayer.luck * (levelplusConfig.Instance.XPPerPoint * 100))) + "% xp gain\n"
+                        + "  +" + ((int) ((modPlayer.luck * 100) / levelplusConfig.Instance.AmmoPerPoint)) + "% chance not to consume ammo";
                     rarity = 0; //white
                     break;
                 case Stat.MYSTICISM:
@@ -177,7 +177,7 @@ namespace levelplus.UI {
                     text = "Mysticism:\n\n"
                         + "  +" + (modPlayer.mysticism * levelplusConfig.Instance.ManaPerPoint) + " max mana (+" + (modPlayer.level * levelplusConfig.Instance.ManaPerLevel) + " from level)\n"
                         + "  +" + (modPlayer.mysticism / levelplusConfig.Instance.ManaRegPerPoint) + " mana regen\n"
-                        + "  -" + System.Math.Clamp((int)(modPlayer.mysticism * (levelplusConfig.Instance.ManaCostPerPoint * 100)), 0f, 99.0f) + "% mana cost (can't be reduced below 1%)";
+                        + "  -" + System.Math.Clamp((int) (modPlayer.mysticism * (levelplusConfig.Instance.ManaCostPerPoint * 100)), 0f, 99.0f) + "% mana cost (can't be reduced below 1%)";
                     rarity = 0; //white
                     break;
                 default:
@@ -194,7 +194,7 @@ namespace levelplus.UI {
         private void pointSpend(UIMouseEvent evt, UIElement listeningElement) {
             SoundEngine.PlaySound(SoundID.MenuTick);
             levelplusModPlayer modPlayer = Main.player[Main.myPlayer].GetModPlayer<levelplusModPlayer>();
-            modPlayer.spend(type, (ushort)(levelplus.SpendModFive.Current ? 5 : levelplus.SpendModTen.Current ? 10 : levelplus.SpendModTwentyFive.Current ? 25 : 1));
+            modPlayer.spend(type, (ushort) (levelplus.SpendModFive.Current ? 5 : levelplus.SpendModTen.Current ? 10 : levelplus.SpendModTwentyFive.Current ? 25 : 1));
         }
     }
 }

--- a/UI/XPBar.cs
+++ b/UI/XPBar.cs
@@ -145,7 +145,7 @@ namespace levelplus.UI {
 
                 averageLevel /= numPlayers;
 
-                Main.instance.MouseText("Level: " + (modPlayer.level + 1) + "\n" + modPlayer.statPoints + " unspent points\n" + ((Main.netMode == NetmodeID.MultiplayerClient) ? numPlayers + " players online\nAverage Level: " + ((int)averageLevel) : ""));
+                Main.instance.MouseText("Level: " + (modPlayer.level + 1) + "\n" + modPlayer.statPoints + " unspent points\n" + ((Main.netMode == NetmodeID.MultiplayerClient) ? numPlayers + " players online\nAverage Level: " + ((int) averageLevel) : ""));
             }
         }
 

--- a/Utility/Commands.cs
+++ b/Utility/Commands.cs
@@ -20,8 +20,7 @@ namespace levelplus.Commands {
         }
     }
 
-    class SetPointsCommand : ModCommand
-    {
+    class SetPointsCommand : ModCommand {
         public override string Command => "setpoints";
 
         public override string Description => "(Level+) Sets the player's available skill points to a given amount.";
@@ -57,8 +56,7 @@ namespace levelplus.Commands {
         }
     }
 
-    class SetXpCommand : ModCommand
-    {
+    class SetXpCommand : ModCommand {
         public override string Command => "setxp";
 
         public override string Description => "(Level+) Sets player experience to a given amount.";
@@ -76,8 +74,7 @@ namespace levelplus.Commands {
         }
     }
 
-    class AddLevelsCommand : ModCommand
-    {
+    class AddLevelsCommand : ModCommand {
         public override string Command => "addlevel";
 
         public override string Description => "(Level+) Adds a given amount of levels to the current player level.";
@@ -95,8 +92,7 @@ namespace levelplus.Commands {
         }
     }
 
-    class SetLevelCommand : ModCommand
-    {
+    class SetLevelCommand : ModCommand {
         public override string Command => "setlevel";
 
         public override string Description => "(Level+) Sets the player level to a given amount.";
@@ -114,8 +110,7 @@ namespace levelplus.Commands {
         }
     }
 
-    class InvestCommand : ModCommand
-    {
+    class InvestCommand : ModCommand {
         public override string Command => "invest";
 
         public override string Description => "(Level+) Invests a given amount of levels into a stat of your choice."
@@ -129,14 +124,14 @@ namespace levelplus.Commands {
             levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
             if (args.Length == 1) {
                 player.InvestParticularAmount(ushort.Parse(args[0]));
-			} else {
+            }
+            else {
                 player.InvestParticularAmount(ushort.Parse(args[0]), ushort.Parse(args[1]));
             }
         }
     }
 
-    class SetInvestmentCommand : ModCommand
-    {
+    class SetInvestmentCommand : ModCommand {
         public override string Command => "setinvestment";
 
         public override string Description => "(Level+) Sets the investment in a stat of your choice to a given amount."
@@ -151,7 +146,7 @@ namespace levelplus.Commands {
             if (!levelplusConfig.Instance.CommandsEnabled) {
                 Main.NewText("Enable commands in the Level+ config to use this command.");
                 return;
-			}
+            }
             levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
             if (args.Length == 1) {
                 player.SetInvestmentToParticularAmount(ushort.Parse(args[0]));

--- a/Utility/Commands.cs
+++ b/Utility/Commands.cs
@@ -1,50 +1,163 @@
-﻿using Terraria.ModLoader;
+﻿using Terraria;
+using Terraria.ModLoader;
 
 namespace levelplus.Commands {
-    class PointCommand : ModCommand {
-        public override string Command => "points";
+    class AddPointsCommand : ModCommand {
+        public override string Command => "addpoints";
 
-        public override string Description => "Adds points";
+        public override string Description => "(Level+) Adds a given amount of skill points to the player's available skill points.";
         public override CommandType Type => CommandType.Chat;
 
-        public override string Usage => "/points <amount>";
+        public override string Usage => "/addpoints <amount>";
 
         public override void Action(CommandCaller caller, string input, string[] args) {
-            if (levelplusConfig.Instance.CommandsEnabled) {
-                levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
-                player.AddPoints(int.Parse(args[0]));
+            if (!levelplusConfig.Instance.CommandsEnabled) {
+                Main.NewText("Enable commands in the Level+ config to use this command.");
+                return;
+            }
+            levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
+            player.AddPoints(int.Parse(args[0]));
+        }
+    }
+
+    class SetPointsCommand : ModCommand
+    {
+        public override string Command => "setpoints";
+
+        public override string Description => "(Level+) Sets the player's available skill points to a given amount.";
+        public override CommandType Type => CommandType.Chat;
+
+        public override string Usage => "/setpoints <amount>";
+
+        public override void Action(CommandCaller caller, string input, string[] args) {
+            if (!levelplusConfig.Instance.CommandsEnabled) {
+                Main.NewText("Enable commands in the Level+ config to use this command.");
+                return;
+            }
+            levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
+            player.SetPoints(int.Parse(args[0]));
+        }
+    }
+
+    class AddXpCommand : ModCommand {
+        public override string Command => "addxp";
+
+        public override string Description => "(Level+) Adds a given amount of experience to the player's current experience.";
+        public override CommandType Type => CommandType.Chat;
+
+        public override string Usage => "/addxp <amount>";
+
+        public override void Action(CommandCaller caller, string input, string[] args) {
+            if (!levelplusConfig.Instance.CommandsEnabled) {
+                Main.NewText("Enable commands in the Level+ config to use this command.");
+                return;
+            }
+            levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
+            player.AddXp(ulong.Parse(args[0]));
+        }
+    }
+
+    class SetXpCommand : ModCommand
+    {
+        public override string Command => "setxp";
+
+        public override string Description => "(Level+) Sets player experience to a given amount.";
+        public override CommandType Type => CommandType.Chat;
+
+        public override string Usage => "/setxp <amount>";
+
+        public override void Action(CommandCaller caller, string input, string[] args) {
+            if (!levelplusConfig.Instance.CommandsEnabled) {
+                Main.NewText("Enable commands in the Level+ config to use this command.");
+                return;
+            }
+            levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
+            player.SetXp(ulong.Parse(args[0]));
+        }
+    }
+
+    class AddLevelsCommand : ModCommand
+    {
+        public override string Command => "addlevel";
+
+        public override string Description => "(Level+) Adds a given amount of levels to the current player level.";
+        public override CommandType Type => CommandType.Chat;
+
+        public override string Usage => "/addlevel <amount>";
+
+        public override void Action(CommandCaller caller, string input, string[] args) {
+            if (!levelplusConfig.Instance.CommandsEnabled) {
+                Main.NewText("Enable commands in the Level+ config to use this command.");
+                return;
+            }
+            levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
+            player.AddLevel(ushort.Parse(args[0]));
+        }
+    }
+
+    class SetLevelCommand : ModCommand
+    {
+        public override string Command => "setlevel";
+
+        public override string Description => "(Level+) Sets the player level to a given amount.";
+        public override CommandType Type => CommandType.Chat;
+
+        public override string Usage => "/setlevel <amount>";
+
+        public override void Action(CommandCaller caller, string input, string[] args) {
+            if (!levelplusConfig.Instance.CommandsEnabled) {
+                Main.NewText("Enable commands in the Level+ config to use this command.");
+                return;
+            }
+            levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
+            player.SetLevel(ushort.Parse(args[0]));
+        }
+    }
+
+    class InvestCommand : ModCommand
+    {
+        public override string Command => "invest";
+
+        public override string Description => "(Level+) Invests a given amount of levels into a stat of your choice."
+            + "\nFor the first command argument: 0 is Constitution, 1-9 is all the other stats in a circle going right starting from just after Constitution."
+            + "\nFor the second command argument: The amount you'd like to invest. Specify no amount to invest all available skill points.";
+        public override CommandType Type => CommandType.Chat;
+
+        public override string Usage => "/invest <stat invest id> <amount, defaults to 65535>";
+
+        public override void Action(CommandCaller caller, string input, string[] args) {
+            levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
+            if (args.Length == 1) {
+                player.InvestParticularAmount(ushort.Parse(args[0]));
+			} else {
+                player.InvestParticularAmount(ushort.Parse(args[0]), ushort.Parse(args[1]));
             }
         }
     }
 
-    class XPCommand : ModCommand {
-        public override string Command => "xp";
+    class SetInvestmentCommand : ModCommand
+    {
+        public override string Command => "setinvestment";
 
-        public override string Description => "Adds xp";
+        public override string Description => "(Level+) Sets the investment in a stat of your choice to a given amount."
+            + "\nWhen setting the investment lower than the previous amount, the points removed will be returned to the player's available skill points."
+            + "\nFor the first command argument: 0 is Constitution, 1-9 is all the other stats in a circle going right starting from just after Constitution."
+            + "\nFor the second command argument: The amount you'd like to have invested. Specify no amount to return all the skill points from that stat.";
         public override CommandType Type => CommandType.Chat;
 
-        public override string Usage => "/xp <amount>";
+        public override string Usage => "/setinvestment <stat invest id> <amount, defaults to 0>";
 
         public override void Action(CommandCaller caller, string input, string[] args) {
-            if (levelplusConfig.Instance.CommandsEnabled) {
-                levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
-                player.AddXp(ulong.Parse(args[0]));
+            if (!levelplusConfig.Instance.CommandsEnabled) {
+                Main.NewText("Enable commands in the Level+ config to use this command.");
+                return;
+			}
+            levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
+            if (args.Length == 1) {
+                player.SetInvestmentToParticularAmount(ushort.Parse(args[0]));
             }
-        }
-    }
-
-    class LevelCommand : ModCommand {
-        public override string Command => "level";
-
-        public override string Description => "Adds levels";
-        public override CommandType Type => CommandType.Chat;
-
-        public override string Usage => "/level <amount>";
-
-        public override void Action(CommandCaller caller, string input, string[] args) {
-            if (levelplusConfig.Instance.CommandsEnabled) {
-                levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
-                player.AddLevel(ushort.Parse(args[0]));
+            else {
+                player.SetInvestmentToParticularAmount(ushort.Parse(args[0]), ushort.Parse(args[1]));
             }
         }
     }

--- a/Utility/Commands.cs
+++ b/Utility/Commands.cs
@@ -52,7 +52,7 @@ namespace levelplus.Commands {
                 return;
             }
             levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
-            player.AddXp(ulong.Parse(args[0]));
+            player.AddXp(ulong.Parse(args[0]), true);
         }
     }
 

--- a/Utility/Commands.cs
+++ b/Utility/Commands.cs
@@ -1,42 +1,43 @@
-﻿using Terraria;
+﻿using System;
+using Terraria;
 using Terraria.ModLoader;
 
 namespace levelplus.Commands {
-    class AddPointsCommand : ModCommand {
-        public override string Command => "addpoints";
-
-        public override string Description => "(Level+) Adds a given amount of skill points to the player's available skill points.";
-        public override CommandType Type => CommandType.Chat;
-
-        public override string Usage => "/addpoints <amount>";
-
-        public override void Action(CommandCaller caller, string input, string[] args) {
-            if (!levelplusConfig.Instance.CommandsEnabled) {
-                Main.NewText("Enable commands in the Level+ config to use this command.");
-                return;
-            }
-            levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
-            player.AddPoints(int.Parse(args[0]));
-        }
-    }
-
-    class SetPointsCommand : ModCommand {
-        public override string Command => "setpoints";
-
-        public override string Description => "(Level+) Sets the player's available skill points to a given amount.";
-        public override CommandType Type => CommandType.Chat;
-
-        public override string Usage => "/setpoints <amount>";
-
-        public override void Action(CommandCaller caller, string input, string[] args) {
-            if (!levelplusConfig.Instance.CommandsEnabled) {
-                Main.NewText("Enable commands in the Level+ config to use this command.");
-                return;
-            }
-            levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
-            player.SetPoints(int.Parse(args[0]));
-        }
-    }
+    //class AddPointsCommand : ModCommand {
+    //    public override string Command => "addpoints";
+    //
+    //    public override string Description => "(Level+) Adds a given amount of skill points to the player's available skill points.";
+    //    public override CommandType Type => CommandType.Chat;
+    //
+    //    public override string Usage => "/addpoints <amount>";
+    //
+    //    public override void Action(CommandCaller caller, string input, string[] args) {
+    //        if (!levelplusConfig.Instance.CommandsEnabled) {
+    //            Main.NewText("Enable commands in the Level+ config to use this command.");
+    //            return;
+    //        }
+    //        levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
+    //        player.AddPoints(int.Parse(args[0]));
+    //    }
+    //}
+    //
+    //class SetPointsCommand : ModCommand {
+    //    public override string Command => "setpoints";
+    //
+    //    public override string Description => "(Level+) Sets the player's available skill points to a given amount.";
+    //    public override CommandType Type => CommandType.Chat;
+    //
+    //    public override string Usage => "/setpoints <amount>";
+    //
+    //    public override void Action(CommandCaller caller, string input, string[] args) {
+    //        if (!levelplusConfig.Instance.CommandsEnabled) {
+    //            Main.NewText("Enable commands in the Level+ config to use this command.");
+    //            return;
+    //        }
+    //        levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
+    //        player.SetPoints(int.Parse(args[0]));
+    //    }
+    //}
 
     class AddXpCommand : ModCommand {
         public override string Command => "addxp";
@@ -106,7 +107,7 @@ namespace levelplus.Commands {
                 return;
             }
             levelplusModPlayer player = caller.Player.GetModPlayer<levelplusModPlayer>();
-            player.SetLevel(ushort.Parse(args[0]));
+            player.SetLevel(Math.Clamp(uint.Parse(args[0]), 1, 65536) - 1);
         }
     }
 

--- a/Utility/Config.cs
+++ b/Utility/Config.cs
@@ -2,8 +2,7 @@
 using Terraria.ModLoader;
 using Terraria.ModLoader.Config;
 
-namespace levelplus
-{
+namespace levelplus {
     public class levelplusConfig : ModConfig {
         public override ConfigScope Mode => ConfigScope.ServerSide;
         public static levelplusConfig Instance => ModContent.GetInstance<levelplusConfig>();
@@ -28,21 +27,21 @@ namespace levelplus
         [Label("Constitution: Health per Point")]
         [Tooltip("How much HP the player gets per point")]
         [Range(0, 25)]
-        [DefaultValue(5)] 
-        public int HealthPerPoint;  
-        
+        [DefaultValue(5)]
+        public int HealthPerPoint;
+
         [Label("Constitution: LifeRegen")]
         [Tooltip("How many Points needed to be spent for 1 LifeReg")]
         [Range(1, 30)]
-        [DefaultValue(20)] 
-        public int HRegenPerPoint;  
-        
+        [DefaultValue(20)]
+        public int HRegenPerPoint;
+
         [Label("Constitution: Defense")]
         [Tooltip("How many Points needed to be spent for 1 Defense")]
         [Range(1, 30)]
-        [DefaultValue(3)] 
-        public int DefensePerPoint;  
-          
+        [DefaultValue(3)]
+        public int DefensePerPoint;
+
         // --- //
         // Intelligence //
         [Label("Intelligence:  Magic Damage")]
@@ -51,14 +50,14 @@ namespace levelplus
         [Range(0.00f, 0.10f)]
         [Increment(0.01f)]
         [DefaultValue(0.01f)]
-        public float MagicDamagePerPoint; 
-        
+        public float MagicDamagePerPoint;
+
         [Label("Intelligence: Magic Crit")]
         [Tooltip("How many Points needed to be spent for 1% Magic Crit")]
         [Range(1, 30)]
-        [DefaultValue(15)] 
-        public int MagicCritPerPoint;  
-        
+        [DefaultValue(15)]
+        public int MagicCritPerPoint;
+
         // --- //
         // Strength //
         [Label("Strength: Melee Damage")]
@@ -67,14 +66,14 @@ namespace levelplus
         [Range(0.00f, 0.10f)]
         [Increment(0.01f)]
         [DefaultValue(0.01f)]
-        public float MeleeDamagePerPoint; 
-        
+        public float MeleeDamagePerPoint;
+
         [Label("Strength: Melee Crit")]
         [Tooltip("How many Points needed to be spent for 1% Melee Crit")]
         [Range(1, 30)]
-        [DefaultValue(15)] 
-        public int MeleeCritPerPoint;  
-        
+        [DefaultValue(15)]
+        public int MeleeCritPerPoint;
+
         // --- //
         // Dexterity //
         [Label("Dexterity: Ranged Damage")]
@@ -83,14 +82,14 @@ namespace levelplus
         [Range(0.00f, 0.25f)]
         [Increment(0.01f)]
         [DefaultValue(0.01f)]
-        public float RangedDamagePerPoint; 
-        
+        public float RangedDamagePerPoint;
+
         [Label("Dexterity: Ranged Crit")]
         [Tooltip("How many Points needed to be spent for 1% Ranged Crit")]
         [Range(1, 30)]
-        [DefaultValue(15)] 
-        public int RangedCritPerPoint;  
-        
+        [DefaultValue(15)]
+        public int RangedCritPerPoint;
+
         // --- //
         // Charisma //
         [Label("Charisma: Summon Damage")]
@@ -99,15 +98,15 @@ namespace levelplus
         [Range(0.00f, 0.25f)]
         [Increment(0.01f)]
         [DefaultValue(0.01f)]
-        public float SummonDamagePerPoint; 
-        
+        public float SummonDamagePerPoint;
+
         [Label("Charisma: Summon Crit")]
         [Tooltip("How many Points needed to be spent for 1% Summon Crit")]
         [Range(1, 30)]
-        [DefaultValue(15)] 
-        public int SummonCritPerPoint;  
-        
-        
+        [DefaultValue(15)]
+        public int SummonCritPerPoint;
+
+
         // --- //
         // Animalia //
         [Label("Animalia: Fishing Skill")]
@@ -116,8 +115,8 @@ namespace levelplus
         [Range(0.00f, 0.10f)]
         [Increment(0.005f)]
         [DefaultValue(0.02f)]
-        public float FishSkillPerPoint; 
-        
+        public float FishSkillPerPoint;
+
 
         //an update removed minionKB as a stat I can modify, come back to this later
         /*
@@ -133,10 +132,10 @@ namespace levelplus
         [Label("Animalia: Max Minions")]
         [Tooltip("How many Points needed to be spent for 1 Minion Capacity")]
         [Range(1, 30)]
-        [DefaultValue(20)] 
-        public int MinionPerPoint;  
-        
-        
+        [DefaultValue(20)]
+        public int MinionPerPoint;
+
+
         // --- //
         // Excavation //
         [Label("Excavation: Pick Speed")]
@@ -145,22 +144,22 @@ namespace levelplus
         [Range(0.00f, 0.05f)]
         [Increment(0.001f)]
         [DefaultValue(0.01f)]
-        public float PickSpeedPerPoint; 
-        
+        public float PickSpeedPerPoint;
+
         [Label("Excavation: Building Speed")]
         [Tooltip("How much Building Speed the player gets per point")]
         [Slider]
         [Range(0.00f, 0.10f)]
         [Increment(0.005f)]
         [DefaultValue(0.02f)]
-        public float BuildSpeedPerPoint; 
-        
+        public float BuildSpeedPerPoint;
+
         [Label("Excavation: Block Range")]
         [Tooltip("How many Points needed to be spent for 1 Placement Range")]
         [Range(1, 30)]
-        [DefaultValue(20)] 
-        public int RangePerPoint;  
-        
+        [DefaultValue(20)]
+        public int RangePerPoint;
+
         // --- //
         // Mobility //
         [Label("Mobility: Run Speed")]
@@ -169,16 +168,16 @@ namespace levelplus
         [Range(0.00f, 0.05f)]
         [Increment(0.001f)]
         [DefaultValue(0.01f)]
-        public float RunSpeedPerPoint; 
-        
+        public float RunSpeedPerPoint;
+
         [Label("Mobility: Acceleration")]
         [Tooltip("How much Acceleration the player gets per point")]
         [Slider]
         [Range(0.00f, 0.10f)]
         [Increment(0.005f)]
         [DefaultValue(0.02f)]
-        public float AccelPerPoint; 
-       
+        public float AccelPerPoint;
+
         [Label("Mobility: Wing Time")]
         [Tooltip("How much Acceleration the player gets per point")]
         [Slider]
@@ -186,7 +185,7 @@ namespace levelplus
         [Increment(0.005f)]
         [DefaultValue(0.02f)]
         public float WingPerPoint;
-        
+
         // --- //
         // Luck //
         [Label("Luck: Bonus Experience")]
@@ -195,36 +194,36 @@ namespace levelplus
         [Range(0.00f, 0.05f)]
         [Increment(0.001f)]
         [DefaultValue(0.01f)]
-        public float XPPerPoint; 
-        
+        public float XPPerPoint;
+
         [Label("Luck: Ammo Consumption")]
         [Tooltip("How much Points you need to Reach 100%")]
         [Range(50, 500)]
-        [DefaultValue(100)] 
+        [DefaultValue(100)]
         [Increment(10)]
-        public int AmmoPerPoint; 
-        
+        public int AmmoPerPoint;
+
         // --- //
         // Mysticism //
         [Label("Mysticism: Mana per Point")]
         [Tooltip("How much Mana the player gets per point")]
         [Range(0, 25)]
-        [DefaultValue(2)] 
-        public int ManaPerPoint;  
-        
+        [DefaultValue(2)]
+        public int ManaPerPoint;
+
         [Label("Mysticism: Mana Regen")]
         [Tooltip("How many Points needed to be spent for 1 ManaReg")]
         [Range(0, 30)]
-        [DefaultValue(15)] 
-        public int ManaRegPerPoint;  
-        
+        [DefaultValue(15)]
+        public int ManaRegPerPoint;
+
         [Label("Mysticism: Mana Cost")]
         [Tooltip("The percent of mana reduced per point invested")]
         [Slider]
         [Range(0.00f, 0.025f)]
         [Increment(0.001f)]
         [DefaultValue(0.001f)]
-        public float ManaCostPerPoint; 
+        public float ManaCostPerPoint;
 
         [SeparatePage]
         [Header("Requires Reload")]
@@ -234,15 +233,15 @@ namespace levelplus
         [DefaultValue(3)]
         [ReloadRequired]
         public int PointsBase;
-        
+
         [Label("Points per Level")]
         [Tooltip("Statpoint Gain per level")]
         [Range(0, 10)]
         [DefaultValue(3)]
         [ReloadRequired]
         public int PointsPerLevel;
-        
-        
+
+
         [Label("Base XP")]
         [Tooltip("Level Up Calculation related")]
         [Range(50, 500)]
@@ -250,7 +249,7 @@ namespace levelplus
         [Increment(25)]
         [ReloadRequired]
         public int XPBase;
-        
+
         [Label("XP Increase")]
         [Tooltip("Level Up Calculation related")]
         [Range(50, 500)]
@@ -258,7 +257,7 @@ namespace levelplus
         [Increment(25)]
         [ReloadRequired]
         public int XPIncrease;
-        
+
         [Label("XP Rate")]
         [Tooltip("Level Up Calculation related")]
         [Slider]
@@ -267,7 +266,7 @@ namespace levelplus
         [DefaultValue(2.0f)]
         [ReloadRequired]
         public float XPRate;
-        
+
         [Label("Mob Experience")]
         [Tooltip("This is the percentage of mob HP you get in XP")]
         [Slider]
@@ -276,16 +275,16 @@ namespace levelplus
         [DefaultValue(0.35f)]
         [ReloadRequired]
         public float MobXP;
-        
+
         [Label("Boss Experience")]
         [Tooltip("This is the percentage of boss HP you get in XP")]
         [Slider]
         [Range(0.0f, 1.0f)]
         [Increment(0.05f)]
-        [DefaultValue(0.25f)] 
+        [DefaultValue(0.25f)]
         [ReloadRequired]
         public float BossXP;
-        
+
         [Label("Scaling")]
         [Tooltip("Turns on mob scaling")]
         [DefaultValue(true)]
@@ -300,7 +299,7 @@ namespace levelplus
         [DefaultValue(0.0250f)]
         [ReloadRequired]
         public float ScalingHealth;
-        
+
         [Label("Enemy Damage")]
         [Tooltip("Multiplies the Damage of Enemies per Average level")]
         [Slider]

--- a/Utility/GlobalNPC.cs
+++ b/Utility/GlobalNPC.cs
@@ -22,8 +22,8 @@ namespace levelplus {
 
                 averageLevel /= numPlayers;
 
-                npc.damage += (int)(npc.damage * (averageLevel * levelplusConfig.Instance.ScalingDamage));
-                npc.lifeMax += (int)(npc.lifeMax * (averageLevel * levelplusConfig.Instance.ScalingHealth));
+                npc.damage += (int) (npc.damage * (averageLevel * levelplusConfig.Instance.ScalingDamage));
+                npc.lifeMax += (int) (npc.lifeMax * (averageLevel * levelplusConfig.Instance.ScalingHealth));
             }
         }
 
@@ -34,10 +34,10 @@ namespace levelplus {
             if (npc.type != NPCID.TargetDummy && !npc.SpawnedFromStatue && !npc.friendly && !npc.townNPC) {
                 ulong amount;
                 if (npc.boss) {
-                    amount = (ulong)(npc.lifeMax * levelplusConfig.Instance.BossXP);
+                    amount = (ulong) (npc.lifeMax * levelplusConfig.Instance.BossXP);
                 }
                 else {
-                    amount = (ulong)(npc.lifeMax * levelplusConfig.Instance.MobXP);
+                    amount = (ulong) (npc.lifeMax * levelplusConfig.Instance.MobXP);
                 }
 
                 if (Main.netMode == NetmodeID.SinglePlayer) {
@@ -47,7 +47,7 @@ namespace levelplus {
                     for (int i = 0; i < npc.playerInteraction.Length; ++i) {
                         if (npc.playerInteraction[i]) {
                             ModPacket packet = levelplus.Instance.GetPacket();
-                            packet.Write((byte)PacketType.XP);
+                            packet.Write((byte) PacketType.XP);
                             packet.Write(amount);
                             packet.Send(i);
                         }

--- a/Utility/ModPlayer.cs
+++ b/Utility/ModPlayer.cs
@@ -45,56 +45,83 @@ namespace levelplus {
         public ushort mysticism { get; set; } //max mana and regen
 
 
-        public void spend(Stat stat, ushort amount) {
-            if (statPoints > 0) {
-                if (statPoints >= amount) {
-                    statPoints -= amount;
-                }
-                else {
-                    amount = statPoints;
-                    statPoints = 0;
-                }
-
-
-                switch (stat) {
-                    case Stat.CONSTITUTION:
-                        constitution += amount;
-                        break;
-                    case Stat.STRENGTH:
-                        strength += amount;
-                        break;
-                    case Stat.INTELLIGENCE:
-                        intelligence += amount;
-                        break;
-                    case Stat.CHARISMA:
-                        charisma += amount;
-                        break;
-                    case Stat.DEXTERITY:
-                        dexterity += amount;
-                        break;
-                    case Stat.MOBILITY:
-                        mobility += amount;
-                        break;
-                    case Stat.EXCAVATION:
-                        excavation += amount;
-                        break;
-                    case Stat.ANIMALIA:
-                        animalia += amount;
-                        break;
-                    case Stat.LUCK:
-                        luck += amount;
-                        break;
-                    case Stat.MYSTICISM:
-                        mysticism += amount;
-                        break;
-                    default:
-                        break;
-                }
+        public void spend(Stat whichStat, ushort howMuch = 1, int givenStatPoints = -1) {
+            int statPointsInt;
+            if (givenStatPoints == -1) {
+                statPointsInt = statPoints;
             }
-        }
-
-        public void spend(Stat stat) {
-            spend(stat, 1);
+            else {
+                statPointsInt = givenStatPoints;
+            }
+            if (statPointsInt == 0)
+                return;
+            ushort theStat = 0;
+            switch (whichStat) {
+                case Stat.CONSTITUTION:
+                    theStat = constitution;
+                    break;
+                case Stat.STRENGTH:
+                    theStat = strength;
+                    break;
+                case Stat.INTELLIGENCE:
+                    theStat = intelligence;
+                    break;
+                case Stat.CHARISMA:
+                    theStat = charisma;
+                    break;
+                case Stat.DEXTERITY:
+                    theStat = dexterity;
+                    break;
+                case Stat.MOBILITY:
+                    theStat = mobility;
+                    break;
+                case Stat.EXCAVATION:
+                    theStat = excavation;
+                    break;
+                case Stat.ANIMALIA:
+                    theStat = animalia;
+                    break;
+                case Stat.LUCK:
+                    theStat = luck;
+                    break;
+                case Stat.MYSTICISM:
+                    theStat = mysticism;
+                    break;
+            }
+            ushort canFit = (ushort) ((ushort) (Math.Min(statPointsInt, howMuch) + theStat) > ushort.MaxValue ? ushort.MaxValue - theStat : Math.Min(statPointsInt, howMuch) + theStat);
+            switch (whichStat) {
+                case Stat.CONSTITUTION:
+                    constitution += canFit;
+                    break;
+                case Stat.STRENGTH:
+                    strength += canFit;
+                    break;
+                case Stat.INTELLIGENCE:
+                    intelligence += canFit;
+                    break;
+                case Stat.CHARISMA:
+                    charisma += canFit;
+                    break;
+                case Stat.DEXTERITY:
+                    dexterity += canFit;
+                    break;
+                case Stat.MOBILITY:
+                    mobility += canFit;
+                    break;
+                case Stat.EXCAVATION:
+                    excavation += canFit;
+                    break;
+                case Stat.ANIMALIA:
+                    animalia += canFit;
+                    break;
+                case Stat.LUCK:
+                    luck += canFit;
+                    break;
+                case Stat.MYSTICISM:
+                    mysticism += canFit;
+                    break;
+            }
+            statPoints = (ushort) Math.Min(ushort.MaxValue, statPointsInt - canFit);
         }
 
         public void initialize() {
@@ -299,22 +326,147 @@ namespace levelplus {
             return true;
         }
 
-        public void AddLevel(ushort level) {
-            statPoints += (ushort)(levelplusConfig.Instance.PointsPerLevel * (level - this.level));
-            this.level += level;
+        public void AddLevel(ushort addThisToLevel) {
+            statPoints += (ushort) Math.Min(ushort.MaxValue - statPoints, levelplusConfig.Instance.PointsPerLevel * addThisToLevel);
+            level += addThisToLevel;
             currentXP = 0;
-            neededXP = CalculateNeededXP(level);
+            neededXP = CalculateNeededXP(addThisToLevel);
         }
 
-        public void AddXp(ulong amount) {
-            currentXP += (ulong)(amount * (1 + (luck * levelplusConfig.Instance.XPPerPoint)));
+        public void SetLevel(ushort setLevelToThis) {
+            level = setLevelToThis;
+            int statPointsInt = levelplusConfig.Instance.PointsPerLevel * setLevelToThis;
+            statPointsInt -= constitution;
+            statPointsInt -= strength;
+            statPointsInt -= intelligence;
+            statPointsInt -= charisma;
+            statPointsInt -= dexterity;
+            statPointsInt -= mysticism;
+            statPointsInt -= mobility;
+            statPointsInt -= animalia;
+            statPointsInt -= luck;
+            statPointsInt -= excavation;
+            statPoints = (ushort) Math.Min(ushort.MaxValue, statPointsInt);
+            currentXP = 0;
+            neededXP = CalculateNeededXP(setLevelToThis);
+        }
+
+        public void AddXp(ulong amountToAdd) {
+            currentXP += amountToAdd;
             if (currentXP >= neededXP) {
                 LevelUp();
             }
         }
 
-        public void AddPoints(int points) {
-            statPoints = (ushort)(statPoints + points);
+        public void SetXp(ulong amountToSetTo) {
+            currentXP = amountToSetTo;
+            if (currentXP >= neededXP) {
+                LevelUp();
+            }
+        }
+
+        public void AddPoints(int amountToAdd) {
+            statPoints += (ushort) Math.Min(ushort.MaxValue - statPoints, amountToAdd);
+        }
+
+        public void SetPoints(int amountToSetTo) {
+            statPoints = (ushort) Math.Min(ushort.MaxValue, amountToSetTo);
+        }
+
+        public void InvestParticularAmount(ushort whichStat, ushort howMuch = 65535, int givenStatPoints = -1) {
+            // The order is starting from the top and going right, around the circle.
+            int statPointsInt;
+            if (givenStatPoints == -1) {
+                statPointsInt = statPoints;
+            }
+            else {
+                statPointsInt = givenStatPoints;
+            }
+            if (statPointsInt == 0)
+                return;
+            switch (whichStat) {
+                case 0:
+                    spend(Stat.CONSTITUTION, howMuch, statPointsInt);
+                    break;
+                case 1:
+                    spend(Stat.MOBILITY, howMuch, statPointsInt);
+                    break;
+                case 2:
+                    spend(Stat.DEXTERITY, howMuch, statPointsInt);
+                    break;
+                case 3:
+                    spend(Stat.LUCK, howMuch, statPointsInt);
+                    break;
+                case 4:
+                    spend(Stat.CHARISMA, howMuch, statPointsInt);
+                    break;
+                case 5:
+                    spend(Stat.ANIMALIA, howMuch, statPointsInt);
+                    break;
+                case 6:
+                    spend(Stat.INTELLIGENCE, howMuch, statPointsInt);
+                    break;
+                case 7:
+                    spend(Stat.MYSTICISM, howMuch, statPointsInt);
+                    break;
+                case 8:
+                    spend(Stat.STRENGTH, howMuch, statPointsInt);
+                    break;
+                case 9:
+                    spend(Stat.EXCAVATION, howMuch, statPointsInt);
+                    break;
+            }
+        }
+
+        public void SetInvestmentToParticularAmount(ushort whichStat, ushort howMuch = 0) {
+            // The order is starting from the top and going right, around the circle.
+            int statPointsInt = statPoints;
+            switch (whichStat) {
+                case 0:
+                    statPointsInt += constitution;
+                    constitution = 0;
+                    break;
+                case 1:
+                    statPointsInt += mobility;
+                    mobility = 0;
+                    break;
+                case 2:
+                    statPointsInt += dexterity;
+                    dexterity = 0;
+                    break;
+                case 3:
+                    statPointsInt += luck;
+                    luck = 0;
+                    break;
+                case 4:
+                    statPointsInt += charisma;
+                    charisma = 0;
+                    break;
+                case 5:
+                    statPointsInt += animalia;
+                    animalia = 0;
+                    break;
+                case 6:
+                    statPointsInt += intelligence;
+                    intelligence = 0;
+                    break;
+                case 7:
+                    statPointsInt += mysticism;
+                    mysticism = 0;
+                    break;
+                case 8:
+                    statPointsInt += strength;
+                    strength = 0;
+                    break;
+                case 9:
+                    statPointsInt += excavation;
+                    excavation = 0;
+                    break;
+            }
+            if (howMuch == 0)
+                statPoints = (ushort) Math.Min(ushort.MaxValue, statPointsInt);
+            else
+                InvestParticularAmount(whichStat, howMuch, statPointsInt);
         }
 
         private void LevelUp() {

--- a/Utility/ModPlayer.cs
+++ b/Utility/ModPlayer.cs
@@ -128,12 +128,12 @@ namespace levelplus {
             level = 0;
             currentXP = 0;
             neededXP = CalculateNeededXP(level);
-            
+
             StatReset();
         }
 
         public void StatReset() {
-            statPoints = (ushort)(level * levelplusConfig.Instance.PointsPerLevel + levelplusConfig.Instance.PointsBase);
+            statPoints = (ushort) (level * levelplusConfig.Instance.PointsPerLevel + levelplusConfig.Instance.PointsBase);
             talents = "--------";
             talentUnspent = 0;
             constitution = 0;
@@ -159,7 +159,7 @@ namespace levelplus {
                 itemsByMod["Terraria"].Add(respec);
             }
 
-            switch ((Weapon)new Random().Next(0, Enum.GetNames(typeof(Weapon)).Length)) {
+            switch ((Weapon) new Random().Next(0, Enum.GetNames(typeof(Weapon)).Length)) {
                 case Weapon.SWORD:
                     itemsByMod["Terraria"].Insert(0, new Item(ItemID.CopperBroadsword));
                     break;
@@ -236,22 +236,22 @@ namespace levelplus {
 
         public override void LoadData(TagCompound tag) {
             if (tag.GetBool("initialized")) {
-                level = (ushort)tag.GetAsShort("level");
-                currentXP = (ulong)tag.GetAsLong("currentXP");
+                level = (ushort) tag.GetAsShort("level");
+                currentXP = (ulong) tag.GetAsLong("currentXP");
                 neededXP = CalculateNeededXP(level);
-                statPoints = (ushort)tag.GetAsShort("points");
+                statPoints = (ushort) tag.GetAsShort("points");
                 talents = tag.Get<string>("talents");
-                talentUnspent = (ushort)tag.GetAsShort("talentPoints");
-                constitution = (ushort)tag.GetAsShort("con");
-                strength = (ushort)tag.GetAsShort("str");
-                intelligence = (ushort)tag.GetAsShort("int");
-                charisma = (ushort)tag.GetAsShort("cha");
-                dexterity = (ushort)tag.GetAsShort("dex");
-                mobility = (ushort)tag.GetAsShort("mob");
-                excavation = (ushort)tag.GetAsShort("exc");
-                animalia = (ushort)tag.GetAsShort("ani");
-                luck = (ushort)(tag.ContainsKey("gra") ? tag.GetAsShort("gra") : tag.GetAsShort("luc"));
-                mysticism = (ushort)tag.GetAsShort("mys");
+                talentUnspent = (ushort) tag.GetAsShort("talentPoints");
+                constitution = (ushort) tag.GetAsShort("con");
+                strength = (ushort) tag.GetAsShort("str");
+                intelligence = (ushort) tag.GetAsShort("int");
+                charisma = (ushort) tag.GetAsShort("cha");
+                dexterity = (ushort) tag.GetAsShort("dex");
+                mobility = (ushort) tag.GetAsShort("mob");
+                excavation = (ushort) tag.GetAsShort("exc");
+                animalia = (ushort) tag.GetAsShort("ani");
+                luck = (ushort) (tag.ContainsKey("gra") ? tag.GetAsShort("gra") : tag.GetAsShort("luc"));
+                mysticism = (ushort) tag.GetAsShort("mys");
 
                 if (currentXP > neededXP) {
                     LevelUp();
@@ -267,7 +267,7 @@ namespace levelplus {
         public override void OnRespawn(Player player) {
             base.OnRespawn(player);
             //lose a quarter of your xp on death
-            currentXP = (ulong)(currentXP * .75);
+            currentXP = (ulong) (currentXP * .75);
         }
 
         public override void ResetEffects() {
@@ -289,7 +289,7 @@ namespace levelplus {
             Player.GetDamage(DamageClass.Summon) *= 1.00f + (charisma * levelplusConfig.Instance.SummonDamagePerPoint);
             Player.GetCritChance(DamageClass.Summon) += charisma / levelplusConfig.Instance.SummonCritPerPoint;
             //animalia
-            Player.fishingSkill += (int)(Player.fishingSkill * (animalia * levelplusConfig.Instance.FishSkillPerPoint));
+            Player.fishingSkill += (int) (Player.fishingSkill * (animalia * levelplusConfig.Instance.FishSkillPerPoint));
             //excavation
             Player.pickSpeed *= 1.00f - (excavation * levelplusConfig.Instance.PickSpeedPerPoint);
             Player.tileSpeed *= 1.00f + (excavation * levelplusConfig.Instance.BuildSpeedPerPoint);
@@ -298,7 +298,7 @@ namespace levelplus {
             //mobility
             Player.maxRunSpeed *= 1.00f + (mobility * levelplusConfig.Instance.RunSpeedPerPoint);
             Player.runAcceleration *= 1.00f + (mobility * levelplusConfig.Instance.AccelPerPoint);
-            Player.wingTimeMax += (int)(Player.wingTimeMax * (mobility * levelplusConfig.Instance.WingPerPoint));
+            Player.wingTimeMax += (int) (Player.wingTimeMax * (mobility * levelplusConfig.Instance.WingPerPoint));
             //mysticism
             Player.statManaMax2 += (levelplusConfig.Instance.ManaPerLevel * level) + (levelplusConfig.Instance.ManaPerPoint * mysticism);
             Player.manaRegen += mysticism / levelplusConfig.Instance.ManaRegPerPoint;
@@ -472,7 +472,7 @@ namespace levelplus {
         private void LevelUp() {
             currentXP -= neededXP;
             ++level;
-            statPoints += (ushort)levelplusConfig.Instance.PointsPerLevel;
+            statPoints += (ushort) levelplusConfig.Instance.PointsPerLevel;
 
             neededXP = CalculateNeededXP(level);
 
@@ -488,7 +488,7 @@ namespace levelplus {
         }
 
         public ulong CalculateNeededXP(ushort level) {
-            return (ulong)(levelplusConfig.Instance.XPIncrease * Math.Pow(level, levelplusConfig.Instance.XPRate) + levelplusConfig.Instance.XPBase);
+            return (ulong) (levelplusConfig.Instance.XPIncrease * Math.Pow(level, levelplusConfig.Instance.XPRate) + levelplusConfig.Instance.XPBase);
         }
 
         public override void clientClone(ModPlayer clientClone) {
@@ -512,7 +512,7 @@ namespace levelplus {
             base.SyncPlayer(toWho, fromWho, newPlayer);
 
             ModPacket packet = Mod.GetPacket();
-            packet.Write((byte)PacketType.PlayerSync);
+            packet.Write((byte) PacketType.PlayerSync);
             AddSyncToPacket(packet);
             packet.Send();
         }
@@ -521,14 +521,14 @@ namespace levelplus {
             base.SendClientChanges(clientPlayer);
             if (!StatsMatch(clientPlayer as levelplusModPlayer)) {
                 ModPacket packet = Mod.GetPacket();
-                packet.Write((byte)PacketType.StatsChanged);
+                packet.Write((byte) PacketType.StatsChanged);
                 AddSyncToPacket(packet);
                 packet.Send();
             }
         }
 
         public void AddSyncToPacket(ModPacket packet) {
-            packet.Write((byte)Player.whoAmI);
+            packet.Write((byte) Player.whoAmI);
             packet.Write(level);
             packet.Write(constitution);
             packet.Write(strength);

--- a/Utility/ModPlayer.cs
+++ b/Utility/ModPlayer.cs
@@ -351,8 +351,11 @@ namespace levelplus {
             neededXP = CalculateNeededXP(setLevelToThis);
         }
 
-        public void AddXp(ulong amountToAdd) {
-            currentXP += amountToAdd;
+        public void AddXp(ulong amountToAdd, bool addRaw = false) {
+            if (addRaw)
+                currentXP += amountToAdd;
+            else
+                currentXP += (ulong) (amountToAdd * (luck * levelplusConfig.Instance.XPPerPoint + 1));
             if (currentXP >= neededXP) {
                 LevelUp();
             }

--- a/Utility/ModPlayer.cs
+++ b/Utility/ModPlayer.cs
@@ -88,7 +88,8 @@ namespace levelplus {
                     theStat = mysticism;
                     break;
             }
-            ushort canFit = (ushort) ((ushort) (Math.Min(statPointsInt, howMuch) + theStat) > ushort.MaxValue ? ushort.MaxValue - theStat : Math.Min(statPointsInt, howMuch) + theStat);
+            ushort canFit = (ushort) Math.Min(ushort.MaxValue - theStat, Math.Min(statPointsInt, howMuch));
+            statPoints = (ushort) Math.Min(ushort.MaxValue, statPointsInt - canFit);
             switch (whichStat) {
                 case Stat.CONSTITUTION:
                     constitution += canFit;
@@ -121,7 +122,6 @@ namespace levelplus {
                     mysticism += canFit;
                     break;
             }
-            statPoints = (ushort) Math.Min(ushort.MaxValue, statPointsInt - canFit);
         }
 
         public void initialize() {
@@ -334,7 +334,7 @@ namespace levelplus {
         }
 
         public void SetLevel(ushort setLevelToThis) {
-            level = setLevelToThis;
+            level = (ushort) Math.Max(0, setLevelToThis - 1);
             int statPointsInt = levelplusConfig.Instance.PointsPerLevel * setLevelToThis;
             statPointsInt -= constitution;
             statPointsInt -= strength;
@@ -346,7 +346,7 @@ namespace levelplus {
             statPointsInt -= animalia;
             statPointsInt -= luck;
             statPointsInt -= excavation;
-            statPoints = (ushort) Math.Min(ushort.MaxValue, statPointsInt);
+            statPoints = (ushort) Math.Max(Math.Min(ushort.MaxValue, statPointsInt), 0);
             currentXP = 0;
             neededXP = CalculateNeededXP(setLevelToThis);
         }

--- a/Utility/ModSystem.cs
+++ b/Utility/ModSystem.cs
@@ -10,84 +10,84 @@ using Terraria.UI;
 namespace levelplus {
     class levelplusModSystem : ModSystem {
 
-		internal GUI gui;
-		public static UserInterface guiInterface;
+        internal GUI gui;
+        public static UserInterface guiInterface;
 
-		internal SpendUI levelUI;
-		public static UserInterface levelInterface;
+        internal SpendUI levelUI;
+        public static UserInterface levelInterface;
 
-		public override void Load() {
-			base.Load();
-			//modify our mana cap
-			IL.Terraria.Player.Update += PlayerManaUpdate;
-			//makes sure UI isn't opened server side
-			if (!Main.dedServ) {
-				gui = new GUI();
-				gui.Activate();
-				guiInterface = new UserInterface();
-				guiInterface.SetState(gui);
+        public override void Load() {
+            base.Load();
+            //modify our mana cap
+            IL.Terraria.Player.Update += PlayerManaUpdate;
+            //makes sure UI isn't opened server side
+            if (!Main.dedServ) {
+                gui = new GUI();
+                gui.Activate();
+                guiInterface = new UserInterface();
+                guiInterface.SetState(gui);
 
-				levelUI = new SpendUI();
-				levelUI.Activate();
-				levelInterface = new UserInterface();
-				levelInterface.SetState(levelUI);
-			}
-		}
+                levelUI = new SpendUI();
+                levelUI.Activate();
+                levelInterface = new UserInterface();
+                levelInterface.SetState(levelUI);
+            }
+        }
 
-        
+
 
         public override void Unload() {
-			base.Unload();
-			if (!Main.dedServ) {
-				SpendUI.visible = false;
-				GUI.visible = false;
-				if (levelInterface != null && guiInterface != null) {
-					levelInterface.SetState(null);
-					guiInterface.SetState(null);
-				}
+            base.Unload();
+            if (!Main.dedServ) {
+                SpendUI.visible = false;
+                GUI.visible = false;
+                if (levelInterface != null && guiInterface != null) {
+                    levelInterface.SetState(null);
+                    guiInterface.SetState(null);
+                }
 
-				gui = null;
-				levelUI = null;
-				UITexture.textures.Clear();
-			}
-		}
+                gui = null;
+                levelUI = null;
+                UITexture.textures.Clear();
+            }
+        }
 
-		public override void UpdateUI(GameTime gameTime) {
-			if (GUI.visible)
+        public override void UpdateUI(GameTime gameTime) {
+            if (GUI.visible)
                 guiInterface?.Update(gameTime);
 
-			if (SpendUI.visible)
+            if (SpendUI.visible)
                 levelInterface?.Update(gameTime);
-		}
+        }
 
-		public override void ModifyInterfaceLayers(List<GameInterfaceLayer> layers) {
-			base.ModifyInterfaceLayers(layers);
+        public override void ModifyInterfaceLayers(List<GameInterfaceLayer> layers) {
+            base.ModifyInterfaceLayers(layers);
 
-			int resourceBarsIndex = layers.FindIndex(layer => layer.Name.Equals("Vanilla: Resource Bars"));
-			//layers.RemoveAt(resourceBarsIndex);
-			layers.Insert(resourceBarsIndex, new LegacyGameInterfaceLayer("Level+: Resource Bars", delegate {
-				if (GUI.visible)
-					guiInterface.Draw(Main.spriteBatch, new GameTime());
-				if (SpendUI.visible)
-					levelInterface.Draw(Main.spriteBatch, new GameTime());
+            int resourceBarsIndex = layers.FindIndex(layer => layer.Name.Equals("Vanilla: Resource Bars"));
+            //layers.RemoveAt(resourceBarsIndex);
+            layers.Insert(resourceBarsIndex, new LegacyGameInterfaceLayer("Level+: Resource Bars", delegate {
+                if (GUI.visible)
+                    guiInterface.Draw(Main.spriteBatch, new GameTime());
+                if (SpendUI.visible)
+                    levelInterface.Draw(Main.spriteBatch, new GameTime());
 
-				return true;
-			}, InterfaceScaleType.UI));
-		}
-		
-		private void PlayerManaUpdate(ILContext il) {
-			//throw new NotImplementedException();
-			ILCursor cursor = new(il);
+                return true;
+            }, InterfaceScaleType.UI));
+        }
 
-			if (!cursor.TryGotoNext(MoveType.Before,
-				i => i.MatchLdfld("Terraria.Player", "statManaMax2"),
-				i => i.MatchLdcI4(400))
-			) {
-				levelplus.Instance.Logger.FatalFormat("Could not find instruction");
-				return;
-			}
+        private void PlayerManaUpdate(ILContext il) {
+            //throw new NotImplementedException();
+            ILCursor cursor = new(il);
 
-			cursor.Next.Next.Operand = 200000;
-		}
-	}
+            if (!cursor.TryGotoNext(MoveType.Before,
+                i => i.MatchLdfld("Terraria.Player", "statManaMax2"),
+                i => i.MatchLdcI4(400))
+            ) {
+                levelplus.Instance.Logger.FatalFormat("Could not find instruction");
+                return;
+            }
+
+            cursor.Next.Next.Operand = 200000;
+        }
+    }
 }

--- a/levelplus.cs
+++ b/levelplus.cs
@@ -36,7 +36,7 @@ namespace levelplus {
 
         public override void HandlePacket(BinaryReader reader, int whoAmI) {
             byte msgType = reader.ReadByte();
-            switch ((PacketType)msgType) {
+            switch ((PacketType) msgType) {
                 case PacketType.XP: //xp gain
                     if (Main.netMode == NetmodeID.MultiplayerClient)
                         Main.LocalPlayer.GetModPlayer<levelplusModPlayer>().AddXp(reader.ReadUInt64());
@@ -47,9 +47,9 @@ namespace levelplus {
                 case PacketType.StatsChanged: //this is called on SendClientChanges
                     byte index = reader.ReadByte();
                     ParsePlayer(reader, index);
-                    if(Main.netMode == NetmodeID.Server) {
+                    if (Main.netMode == NetmodeID.Server) {
                         ModPacket packet = GetPacket();
-                        packet.Write((byte)PacketType.StatsChanged);
+                        packet.Write((byte) PacketType.StatsChanged);
                         Main.player[index].GetModPlayer<levelplusModPlayer>().AddSyncToPacket(packet);
                         packet.Send(-1, index);
                     }


### PR DESCRIPTION
Can now set points, level, and xp
Can now set investment and add investments
Changed the commands in-game to be add or set instead of just 'level' etc for clarity
Trying to use a command without commands enabled will tell the player to enable commands in the config
Invest command can be used without enabling commands, as it is already something that players can do without the command.
Rewrote command descriptions
Put checks into existing commands to avoid overflows for commands that were likely to cause them
When setting investments and getting back enough to bring available skill points over ushort max, sets to ushort max instead
Cannot invest enough points to cause an overload
allocation with the menu will not overflow stat categories
Investment commands cascade through the regular allocation method, which was overhauled. Makes the code cleaner
gg
