### PR TITLE
Additions for 1.2.0 + small patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.png~
 *.kra~
 *.sln
+.idea/
+.DS_Store

--- a/Common/Players/LevelPlayer.cs
+++ b/Common/Players/LevelPlayer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) BitWiser.
+// Copyright (c) BitWiser.
 // Licensed under the Apache License, Version 2.0.
 
 using LevelPlus.Common.Configs;
@@ -7,10 +7,12 @@ using LevelPlus.Common.UI.SpendUI;
 using LevelPlus.Content.Items;
 using System;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.Audio;
 using Terraria.GameInput;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 
@@ -31,7 +33,8 @@ namespace LevelPlus.Common.Players {
       get => _xp;
       private set {
         if (XpToLevel(value) >= Level && !Main.dedServ) {
-          SoundEngine.PlaySound(new SoundStyle("LevelPlus/Assets/Sounds/Level"));
+          SoundEngine.PlaySound(new SoundStyle("LevelPlus/Assets/Sounds/LevelUp"));
+          CombatText.NewText(Player.getRect(), Color.GreenYellow, Language.GetTextValue("Mods.LevelPlus.Popup.LevelUp"));
         }
         _xp = value;
         Points += ServerConfig.Instance.Level_Points;
@@ -89,10 +92,10 @@ namespace LevelPlus.Common.Players {
       Xp = Math.Clamp(amount + Xp,
         0,
         long.MaxValue);
-      /* popup text for xp gain
-      AdvancedPopupRequest request;
-      request.
-      PopupText.NewText()*/
+      if (!Main.dedServ)
+      {
+        CombatText.NewText(Player.getRect(), Color.Yellow, Language.GetTextValue("Mods.LevelPlus.Popup.XpGain", amount), true);
+      }
     }
 
     public void SetXp(long value) {

--- a/Common/Players/LevelPlayer.cs
+++ b/Common/Players/LevelPlayer.cs
@@ -34,7 +34,7 @@ namespace LevelPlus.Common.Players {
       private set {
         if (XpToLevel(value) >= Level && !Main.dedServ) {
           SoundEngine.PlaySound(new SoundStyle("LevelPlus/Assets/Sounds/LevelUp"));
-          CombatText.NewText(Player.getRect(), Color.GreenYellow, Language.GetTextValue("Mods.LevelPlus.Popup.LevelUp"));
+          CombatText.NewText(Player.getRect(), Color.GreenYellow, Language.GetTextValue("Mods.LevelPlus.Popup.LevelUp"), true);
         }
         _xp = value;
         Points += ServerConfig.Instance.Level_Points;
@@ -94,7 +94,7 @@ namespace LevelPlus.Common.Players {
         long.MaxValue);
       if (!Main.dedServ)
       {
-        CombatText.NewText(Player.getRect(), Color.Yellow, Language.GetTextValue("Mods.LevelPlus.Popup.XpGain", amount), true);
+        CombatText.NewText(Player.getRect(), Color.Yellow, Language.GetTextValue("Mods.LevelPlus.Popup.XpGain", amount));
       }
     }
 

--- a/Common/ScalingGlobalNPC.cs
+++ b/Common/ScalingGlobalNPC.cs
@@ -4,9 +4,11 @@
 using LevelPlus.Common.Configs;
 using LevelPlus.Common.Players;
 using System;
+using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace LevelPlus.Common {
@@ -14,9 +16,10 @@ namespace LevelPlus.Common {
     public override bool InstancePerEntity => true;
 
     float xpScalar = 1.0f;
-    int numPlayers = 0;
+    int numPlayers = 1;
     float topDamage;
     private long CalculateMobXP(int npcLife, int npcDefence) {
+      numPlayers = Math.Max(numPlayers, 1); // Avoid divide by zero
       float playerScalar = numPlayers == 1 ? 1.0f : (float)(Math.Log(numPlayers - 1) + 1.25f) / numPlayers;
       return (long)(
         (npcLife / xpScalar / 3
@@ -56,9 +59,23 @@ namespace LevelPlus.Common {
     }
     public override void OnKill(NPC npc) {
       base.OnKill(npc);
-      if (npc.type != NPCID.TargetDummy && !npc.SpawnedFromStatue && !npc.friendly && !npc.townNPC) {
+      if (npc.type != NPCID.TargetDummy && !npc.SpawnedFromStatue && !npc.friendly && !npc.townNPC && !npc.CountsAsACritter && !npc.immortal) {
+        
+        // Mob dying by jumping into lava without player involvement should not give XP
+        if (npc.lastInteraction == 255) {
+          return;
+        }
+        
         long amount = CalculateMobXP((int)(npc.lifeMax * (npc.aiStyle != NPCAIStyleID.Worm ? 1.0f : 0.166f)), npc.defense);
 
+        // Bestiary increments only when player kills the mob. Double the xp for the first kill.
+        int killCount = Main.BestiaryTracker.Kills.GetKillCount(npc);
+        if (killCount == 1)
+        {
+          amount *= 2;
+          CombatText.NewText(npc.getRect(), Color.Aqua, Language.GetTextValue("Mods.LevelPlus.Popup.BestiaryUnlocked"), true);
+        }
+        
         if (Main.netMode == NetmodeID.SinglePlayer) {
           Main.LocalPlayer.GetModPlayer<LevelPlayer>().AddXp(amount);
         }

--- a/Content/Items/Respec.cs
+++ b/Content/Items/Respec.cs
@@ -33,6 +33,7 @@ namespace LevelPlus.Content.Items
           .AddIngredient(ItemID.SoulofFlight, 1)
           .AddIngredient(ItemID.SoulofNight, 1)
           .AddTile(TileID.MythrilAnvil)
+          .DisableDecraft()
           .Register();
 
       CreateRecipe()
@@ -40,6 +41,7 @@ namespace LevelPlus.Content.Items
           .AddIngredient(ItemID.SoulofFlight, 1)
           .AddIngredient(ItemID.SoulofLight, 1)
           .AddTile(TileID.MythrilAnvil)
+          .DisableDecraft()
           .Register();
 
       CreateRecipe()
@@ -47,6 +49,7 @@ namespace LevelPlus.Content.Items
           .AddIngredient(ItemID.SoulofFlight, 1)
           .AddIngredient(ItemID.SoulofNight, 1)
           .AddTile(TileID.MythrilAnvil)
+          .DisableDecraft()
           .Register();
 
       CreateRecipe()
@@ -54,6 +57,7 @@ namespace LevelPlus.Content.Items
           .AddIngredient(ItemID.SoulofFlight, 1)
           .AddIngredient(ItemID.SoulofLight, 1)
           .AddTile(TileID.MythrilAnvil)
+          .DisableDecraft()
           .Register();
     }
 

--- a/Localization/en-US_Mods.LevelPlus.hjson
+++ b/Localization/en-US_Mods.LevelPlus.hjson
@@ -14,3 +14,9 @@ Keybinds: {
 	SpendFive.DisplayName: Spend 5 points
 	OpenSpendUI.DisplayName: Open stat UI
 }
+
+Popup: {
+	LevelUp: Level Up!
+	XpGain: + {0} XP
+	BestiaryUnlocked: Bestiary Unlocked!
+}


### PR DESCRIPTION
Game related:
- Disabled de-crafting of Respec item to prevent possible progression-breaking issues
- Implemented "+XP" popups
- Implemented "Level Up!" popups
- Implemented Bestiary unlocked popups and bonuses
- Added localization for all new implementations
- Fixed mobs granting XP when they were not interacted with at all
- Fixed divide-by-zero causing wrong XP calculations
- Fixed path to the LevelUp sound file

Project related:
- Added `.idea/` and `.DS_Store` to .gitignore to account for JetBrains IDEs and MacOS